### PR TITLE
Wire tarot readings backend to current Apex-01 services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,13 @@
 # Required for real Apex-01 / Simphoni language calls.
-SIMPHONI_API_BASE_URL=http://127.0.0.1:5037
+SIMPHONI_API_BASE_URL=http://127.0.0.1:20821
 SIMPHONI_MODEL=ministral-3:14b
+SIMPHONI_FALLBACK_BASE_URLS=http://127.0.0.1:20822,http://127.0.0.1:20823
 
 # Optional tuning.
 SIMPHONI_TIMEOUT_MS=120000
 SIMPHONI_STREAMING_ENABLED=true
 SIMPHONI_NON_STREAMING_FALLBACK=true
+SIMPHONI_ROTATE_BASE_URLS=true
 
 # Optional comma-separated fallback bases. Keep secrets out of this file.
-# SIMPHONI_FALLBACK_BASE_URLS=http://127.0.0.1:8768,http://127.0.0.1:11435
+# SIMPHONI_FALLBACK_BASE_URLS=http://127.0.0.1:20822,http://127.0.0.1:20823

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Required for real Apex-01 / Simphoni language calls.
+SIMPHONI_API_BASE_URL=http://127.0.0.1:5037
+SIMPHONI_MODEL=ministral-3:14b
+
+# Optional tuning.
+SIMPHONI_TIMEOUT_MS=120000
+SIMPHONI_STREAMING_ENABLED=true
+SIMPHONI_NON_STREAMING_FALLBACK=true
+
+# Optional comma-separated fallback bases. Keep secrets out of this file.
+# SIMPHONI_FALLBACK_BASE_URLS=http://127.0.0.1:8768,http://127.0.0.1:11435

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ node backend/server.js
 
 Required:
 
-- `SIMPHONI_API_BASE_URL`: Apex-01 / Simphoni API base URL. Use the same-origin edge, Orkest API, Simphoni core API, or another configured service base that exposes compatible language routes.
+- `SIMPHONI_API_BASE_URL`: Apex-01 / Simphoni API base URL. On apex-01 the Twilight Tarot Garden launchd profile points this at the first local llama.cpp node, `http://127.0.0.1:20821`.
 - `SIMPHONI_MODEL`: Model name passed to the upstream service.
 
 Optional:
@@ -26,6 +26,7 @@ Optional:
 - `SIMPHONI_STREAMING_ENABLED`: defaults to `true`; sends `stream: true` upstream and streams text to `/stream` callers.
 - `SIMPHONI_NON_STREAMING_FALLBACK`: defaults to `true`; retries with `stream: false` if streaming routes are unavailable.
 - `SIMPHONI_FALLBACK_BASE_URLS`: comma-separated fallback base URLs tried after the primary base.
+- `SIMPHONI_ROTATE_BASE_URLS`: defaults to `true`; rotates the starting base URL per request so the three-node apex-01 pool receives traffic while keeping the remaining nodes as ordered fallbacks.
 - `SIMPHONI_INCLUDE_LOCAL_FALLBACKS`: enables built-in Apex-01 local fallbacks. When no base URL is configured, local development falls back to `127.0.0.1:5037`, `127.0.0.1:8768`, and `127.0.0.1:11435`.
 - `SIMPHONI_API_KEY` or `SIMPHONI_API_TOKEN`: optional bearer credential for deployments that require one.
 
@@ -40,6 +41,18 @@ The backend tries compatible endpoints in this order for chat-style tarot prompt
 For prompt-style calls it tries `/api/generate`, `/v1/completions`, then `/api/chat`. Streaming responses may be newline-delimited JSON or SSE `data:` events and may end with `[DONE]`. Malformed stream lines are ignored and counted in response metadata instead of crashing the request.
 
 `GET /healthz` reports provider, model/base URL presence, timeout, streaming settings, and redacted base URLs. It never reports API keys or tokens.
+
+## Apex-01 Twilight Tarot Garden Runtime
+
+The hosted Simphoni route `/communiti/twilight-tarot-garden` is served by `Simphoni-SPA`, but the route-owned JSX/CSS implementation now lives in this extracted repo under `frontend/src/spa/` and `frontend/src/`. `Simphoni-SPA` imports it through the `@tarot-readings` Vite alias.
+
+On apex-01, the persistent local runtime is:
+
+- `ai.simphoni.tarot-llama-nodes`: keeps three llama.cpp `ministral-3:14b` nodes listening on `127.0.0.1:20821`, `20822`, and `20823`.
+- `ai.simphoni.tarot-readings-backend`: runs this backend on `127.0.0.1:5011` with `SIMPHONI_API_BASE_URL=http://127.0.0.1:20821` and fallback bases for `20822`/`20823`.
+- `ai.simphoni.orkest`: proxies same-origin browser calls from `https://simphoni.ai/api/psychic/*` to the tarot backend.
+
+No browser-side token is required. The browser calls same-origin `/api/psychic/*`, Orkest proxies to the tarot backend, and the backend talks to the local llama.cpp nodes.
 
 If you're running as a container, pass runtime configuration with `--env-file .env` or Kubernetes environment variables. The Kubernetes manifests keep the current image tags and host values while using `SIMPHONI_API_BASE_URL`, `SIMPHONI_MODEL`, `SIMPHONI_TIMEOUT_MS`, and `SIMPHONI_STREAMING_ENABLED`.
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,47 @@
-# Helpful tips to set your environment
+# Tarot Readings
 
 Make sure your environment has npm and Node.js before doing any work so that your app can run!
 
-If you are missing any npm dependencies, you can run `npm install` from the root project directory. There are two `package.json` files that contain the dependencies.
+If you are missing any npm dependencies, run `npm install` inside `backend/` and `frontend/`. There are two `package.json` files because the API server and Vite app are installed separately.
 
-There is a backend script that is required to make API requests on your behalf. 
-This backend server will make calls to OpenAI, so you will need to create a `.env` file and provide your OpenAI API key.
-You can create this file by running the following command from the root project directory with your API key.
+## Backend LLM Configuration
 
-`echo OPENAI_API_KEY=<your-api-key-here> > .env`
+The backend routes tarot prompts through the current Apex-01 / Simphoni language service flow. Configure the API base and model with environment variables; do not commit credentials or local `.env` files.
 
-Start the backend server from the root project directory.
+For local development from the repository root:
 
-`node backend/server.js`
+```sh
+cp .env.example .env
+node backend/server.js
+```
 
-If you're running as a container, you'll need to use the `--env-file .env` option in order to provide the API key to the container.
+Required:
+
+- `SIMPHONI_API_BASE_URL`: Apex-01 / Simphoni API base URL. Use the same-origin edge, Orkest API, Simphoni core API, or another configured service base that exposes compatible language routes.
+- `SIMPHONI_MODEL`: Model name passed to the upstream service.
+
+Optional:
+
+- `SIMPHONI_TIMEOUT_MS`: upstream request timeout, default `120000`.
+- `SIMPHONI_STREAMING_ENABLED`: defaults to `true`; sends `stream: true` upstream and streams text to `/stream` callers.
+- `SIMPHONI_NON_STREAMING_FALLBACK`: defaults to `true`; retries with `stream: false` if streaming routes are unavailable.
+- `SIMPHONI_FALLBACK_BASE_URLS`: comma-separated fallback base URLs tried after the primary base.
+- `SIMPHONI_INCLUDE_LOCAL_FALLBACKS`: enables built-in Apex-01 local fallbacks. When no base URL is configured, local development falls back to `127.0.0.1:5037`, `127.0.0.1:8768`, and `127.0.0.1:11435`.
+- `SIMPHONI_API_KEY` or `SIMPHONI_API_TOKEN`: optional bearer credential for deployments that require one.
+
+Legacy env names `CURRENT_MODEL`, `OPENAI_MODEL`, `OPENAI_BASE_URL`, and `OLLAMA_BASE_URL` are still accepted as compatibility fallbacks, but new deployments should use the `SIMPHONI_*` names.
+
+The backend tries compatible endpoints in this order for chat-style tarot prompts:
+
+1. `/api/chat`
+2. `/v1/chat/completions`
+3. `/api/generate`
+
+For prompt-style calls it tries `/api/generate`, `/v1/completions`, then `/api/chat`. Streaming responses may be newline-delimited JSON or SSE `data:` events and may end with `[DONE]`. Malformed stream lines are ignored and counted in response metadata instead of crashing the request.
+
+`GET /healthz` reports provider, model/base URL presence, timeout, streaming settings, and redacted base URLs. It never reports API keys or tokens.
+
+If you're running as a container, pass runtime configuration with `--env-file .env` or Kubernetes environment variables. The Kubernetes manifests keep the current image tags and host values while using `SIMPHONI_API_BASE_URL`, `SIMPHONI_MODEL`, `SIMPHONI_TIMEOUT_MS`, and `SIMPHONI_STREAMING_ENABLED`.
 
 # Container Builds
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,6 @@ FROM node:23.5-alpine3.20
 WORKDIR /usr/local/app
 
 COPY . ./backend
-COPY .env ./.env
 COPY package.json package.json
 COPY package-lock.json package-lock.json
 

--- a/backend/lib/simphoniClient.js
+++ b/backend/lib/simphoniClient.js
@@ -8,6 +8,7 @@ const DEFAULT_LOCAL_BASE_URLS = [
   'http://127.0.0.1:11435',
 ];
 const DEFAULT_MAX_ERROR_DETAIL = 500;
+let baseUrlCursor = 0;
 
 function cleanBaseUrl(value) {
   if (!value || typeof value !== 'string') return null;
@@ -122,6 +123,7 @@ function buildClientConfig(env = process.env) {
     timeoutMs: parsePositiveInteger(env.SIMPHONI_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
     streamingEnabled: parseBoolean(env.SIMPHONI_STREAMING_ENABLED, true),
     nonStreamingFallbackEnabled: parseBoolean(env.SIMPHONI_NON_STREAMING_FALLBACK, true),
+    rotateBaseUrls: parseBoolean(env.SIMPHONI_ROTATE_BASE_URLS, true),
     apiKey: env.SIMPHONI_API_KEY || env.SIMPHONI_API_TOKEN || null,
   };
 }
@@ -453,8 +455,9 @@ async function requestLanguage({ config, messages, prompt, options, onText }) {
     ? [true, ...(config.nonStreamingFallbackEnabled ? [false] : [])]
     : [false];
   const failures = [];
+  const baseUrls = orderedBaseUrls(config);
 
-  for (const baseUrl of config.baseUrls) {
+  for (const baseUrl of baseUrls) {
     for (const stream of streams) {
       const attempts = buildEndpointAttempts({
         messages,
@@ -509,6 +512,17 @@ async function requestLanguage({ config, messages, prompt, options, onText }) {
   });
 }
 
+function orderedBaseUrls(config) {
+  const baseUrls = Array.isArray(config?.baseUrls) ? config.baseUrls.slice() : [];
+  if (baseUrls.length <= 1 || config.rotateBaseUrls === false) {
+    return baseUrls;
+  }
+
+  const offset = baseUrlCursor % baseUrls.length;
+  baseUrlCursor = (baseUrlCursor + 1) % baseUrls.length;
+  return baseUrls.slice(offset).concat(baseUrls.slice(0, offset));
+}
+
 function healthMetadata(config) {
   return {
     provider: config.provider,
@@ -519,6 +533,7 @@ function healthMetadata(config) {
     base_urls: config.baseUrls.map(redactBaseUrl),
     streaming_enabled: config.streamingEnabled,
     non_streaming_fallback_enabled: config.nonStreamingFallbackEnabled,
+    rotate_base_urls: config.rotateBaseUrls,
     timeout_ms: config.timeoutMs,
     endpoints: {
       chat: ['/api/chat', '/v1/chat/completions', '/api/generate'],
@@ -538,6 +553,7 @@ module.exports = {
   extractTextFromPayload,
   healthMetadata,
   messagesToPrompt,
+  orderedBaseUrls,
   parseBoolean,
   parsePositiveInteger,
   parseStreamLine,

--- a/backend/lib/simphoniClient.js
+++ b/backend/lib/simphoniClient.js
@@ -1,0 +1,547 @@
+const axios = require('axios');
+
+const DEFAULT_TIMEOUT_MS = 120000;
+const DEFAULT_PROVIDER = 'simphoni-apex';
+const DEFAULT_LOCAL_BASE_URLS = [
+  'http://127.0.0.1:5037',
+  'http://127.0.0.1:8768',
+  'http://127.0.0.1:11435',
+];
+const DEFAULT_MAX_ERROR_DETAIL = 500;
+
+function cleanBaseUrl(value) {
+  if (!value || typeof value !== 'string') return null;
+  const trimmed = value.trim().replace(/\/+$/, '');
+  return trimmed || null;
+}
+
+function splitCsv(value) {
+  if (!value || typeof value !== 'string') return [];
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function buildBaseList(values = []) {
+  const seen = new Set();
+  const bases = [];
+
+  values.flat().forEach((value) => {
+    const cleaned = cleanBaseUrl(value);
+    if (!cleaned || seen.has(cleaned)) return;
+    seen.add(cleaned);
+    bases.push(cleaned);
+  });
+
+  return bases;
+}
+
+function parseBoolean(value, fallback = false) {
+  if (value === undefined || value === null || value === '') return fallback;
+  if (typeof value === 'boolean') return value;
+  const normalized = String(value).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function redactBaseUrl(value) {
+  const cleaned = cleanBaseUrl(value);
+  if (!cleaned) return null;
+
+  try {
+    const url = new URL(cleaned);
+    url.username = '';
+    url.password = '';
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return cleaned.replace(/\/\/[^/@]+@/, '//[redacted]@');
+  }
+}
+
+function sanitizeErrorDetail(detail, maxLength = DEFAULT_MAX_ERROR_DETAIL) {
+  if (detail === undefined || detail === null) return undefined;
+
+  let text;
+  if (typeof detail === 'string') {
+    text = detail;
+  } else {
+    try {
+      text = JSON.stringify(detail);
+    } catch {
+      text = String(detail);
+    }
+  }
+
+  text = text
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [redacted]')
+    .replace(/"api[_-]?key"\s*:\s*"[^"]+"/gi, '"api_key":"[redacted]"')
+    .replace(/"token"\s*:\s*"[^"]+"/gi, '"token":"[redacted]"');
+
+  return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+}
+
+function buildClientConfig(env = process.env) {
+  const explicitBases = buildBaseList([
+    env.SIMPHONI_API_BASE_URL,
+    env.SIMPHONI_BASE_URL,
+    env.SIMPHONI_CORE_API_BASE,
+    env.SIMPHONI_PY_API_BASE,
+    env.SIMPHONI_LLM_GATEWAY_BASE,
+    env.OPENAI_BASE_URL,
+    env.OLLAMA_BASE_URL,
+  ]);
+
+  const configuredFallbacks = buildBaseList([
+    splitCsv(env.SIMPHONI_FALLBACK_BASE_URLS),
+    splitCsv(env.SIMPHONI_API_FALLBACK_BASE_URLS),
+  ]);
+
+  const includeLocalFallbacks = parseBoolean(
+    env.SIMPHONI_INCLUDE_LOCAL_FALLBACKS,
+    explicitBases.length === 0 && configuredFallbacks.length === 0,
+  );
+
+  const fallbackBases = buildBaseList([
+    configuredFallbacks,
+    includeLocalFallbacks ? DEFAULT_LOCAL_BASE_URLS : [],
+  ]);
+
+  return {
+    provider: DEFAULT_PROVIDER,
+    baseUrls: buildBaseList([explicitBases, fallbackBases]),
+    configuredBaseUrls: explicitBases,
+    fallbackBaseUrls: fallbackBases,
+    model: env.SIMPHONI_MODEL || env.CURRENT_MODEL || env.OPENAI_MODEL || null,
+    timeoutMs: parsePositiveInteger(env.SIMPHONI_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+    streamingEnabled: parseBoolean(env.SIMPHONI_STREAMING_ENABLED, true),
+    nonStreamingFallbackEnabled: parseBoolean(env.SIMPHONI_NON_STREAMING_FALLBACK, true),
+    apiKey: env.SIMPHONI_API_KEY || env.SIMPHONI_API_TOKEN || null,
+  };
+}
+
+function messagesToPrompt(messages) {
+  if (!Array.isArray(messages)) return String(messages || '');
+
+  return messages
+    .map((message) => {
+      const role = (message?.role || 'user').toUpperCase();
+      const content = typeof message?.content === 'string'
+        ? message.content
+        : JSON.stringify(message?.content ?? '');
+      return `${role}: ${content}`;
+    })
+    .join('\n')
+    .concat('\nASSISTANT:');
+}
+
+function extractTextFromPayload(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+  if (typeof payload.response === 'string') return payload.response;
+  if (typeof payload.text === 'string') return payload.text;
+  if (typeof payload.content === 'string') return payload.content;
+  if (payload.message && typeof payload.message.content === 'string') {
+    return payload.message.content;
+  }
+
+  const choice = Array.isArray(payload.choices) ? payload.choices[0] : null;
+  if (typeof choice?.delta?.content === 'string') return choice.delta.content;
+  if (typeof choice?.message?.content === 'string') return choice.message.content;
+  if (typeof choice?.text === 'string') return choice.text;
+
+  return null;
+}
+
+function applyTextUpdate(state, nextText) {
+  if (!nextText) return { aggregate: state.aggregate, delta: '' };
+  if (!state.aggregate) {
+    state.aggregate = nextText;
+    return { aggregate: state.aggregate, delta: nextText };
+  }
+  if (nextText.startsWith(state.aggregate)) {
+    const delta = nextText.slice(state.aggregate.length);
+    state.aggregate = nextText;
+    return { aggregate: state.aggregate, delta };
+  }
+
+  state.aggregate += nextText;
+  return { aggregate: state.aggregate, delta: nextText };
+}
+
+function parseStreamLine(rawLine) {
+  let line = String(rawLine || '').trim();
+  if (!line) return null;
+  if (line.startsWith(':') || line.startsWith('event:') || line.startsWith('id:')) return null;
+  if (line === '[DONE]') return { done: true };
+
+  if (line.startsWith('data:')) {
+    line = line.slice('data:'.length).trim();
+  }
+
+  if (!line) return null;
+  if (line === '[DONE]') return { done: true };
+
+  try {
+    const payload = JSON.parse(line);
+    if (payload?.error) {
+      const errorMessage = typeof payload.error === 'string'
+        ? payload.error
+        : payload.error?.message || JSON.stringify(payload.error);
+      return { error: errorMessage, payload };
+    }
+
+    return {
+      text: extractTextFromPayload(payload),
+      done: payload.done === true || payload.stop === true,
+      payload,
+    };
+  } catch (error) {
+    return {
+      parseError: {
+        message: error.message,
+        line: sanitizeErrorDetail(line, 160),
+      },
+    };
+  }
+}
+
+function handleParsedStreamLine(parsed, state, onText) {
+  if (!parsed) return;
+  if (parsed.parseError) {
+    state.parseErrors.push(parsed.parseError);
+    return;
+  }
+  if (parsed.payload) state.lastPayload = parsed.payload;
+  if (parsed.error) {
+    const error = new Error(parsed.error);
+    error.status = 502;
+    error.detail = parsed.error;
+    throw error;
+  }
+  if (parsed.done) state.done = true;
+  if (parsed.text) {
+    const { delta } = applyTextUpdate(state, parsed.text);
+    if (delta) onText?.(delta, state.aggregate);
+  }
+}
+
+async function collectStreamText(stream, { onText } = {}) {
+  if (!stream || typeof stream[Symbol.asyncIterator] !== 'function') {
+    return { text: '', raw: null, done: false, parseErrors: [] };
+  }
+
+  const state = {
+    aggregate: '',
+    done: false,
+    lastPayload: null,
+    parseErrors: [],
+  };
+  let buffer = '';
+
+  for await (const chunk of stream) {
+    buffer += chunk.toString('utf8');
+    const lines = buffer.split(/\r?\n/);
+    buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      handleParsedStreamLine(parseStreamLine(line), state, onText);
+    }
+  }
+
+  if (buffer.trim()) {
+    handleParsedStreamLine(parseStreamLine(buffer), state, onText);
+  }
+
+  return {
+    text: state.aggregate.trim(),
+    raw: state.lastPayload,
+    done: state.done,
+    parseErrors: state.parseErrors,
+  };
+}
+
+async function readBodyText(body) {
+  if (!body) return '';
+  if (typeof body === 'string') return body;
+  if (Buffer.isBuffer(body)) return body.toString('utf8');
+  if (typeof body[Symbol.asyncIterator] !== 'function') return '';
+
+  let text = '';
+  for await (const chunk of body) {
+    text += chunk.toString('utf8');
+  }
+  return text;
+}
+
+function makeLanguageError(message, options = {}) {
+  const error = new Error(message);
+  Object.assign(error, options);
+  return error;
+}
+
+function buildEndpointAttempts({ messages, prompt, options, stream, model }) {
+  const hasMessages = Array.isArray(messages) && messages.length > 0;
+  const promptText = typeof prompt === 'string' ? prompt : messagesToPrompt(messages);
+  const requestOptions = options || undefined;
+
+  if (hasMessages) {
+    return [
+      {
+        path: '/api/chat',
+        mode: 'chat',
+        body: { model, messages, stream, options: requestOptions },
+      },
+      {
+        path: '/v1/chat/completions',
+        mode: 'chat.completions',
+        body: { model, messages, stream, ...openAiOptions(options) },
+      },
+      {
+        path: '/api/generate',
+        mode: 'generate',
+        body: { model, prompt: promptText, stream, options: requestOptions },
+      },
+    ];
+  }
+
+  return [
+    {
+      path: '/api/generate',
+      mode: 'generate',
+      body: { model, prompt: promptText, stream, options: requestOptions },
+    },
+    {
+      path: '/v1/completions',
+      mode: 'completions',
+      body: { model, prompt: promptText, stream, ...openAiOptions(options) },
+    },
+    {
+      path: '/api/chat',
+      mode: 'chat',
+      body: {
+        model,
+        messages: [{ role: 'user', content: promptText }],
+        stream,
+        options: requestOptions,
+      },
+    },
+  ];
+}
+
+function openAiOptions(options = {}) {
+  const mapped = {};
+  if (options.temperature !== undefined) mapped.temperature = options.temperature;
+  if (options.top_p !== undefined) mapped.top_p = options.top_p;
+  if (options.max_tokens !== undefined) mapped.max_tokens = options.max_tokens;
+  if (options.num_predict !== undefined) mapped.max_tokens = options.num_predict;
+  return mapped;
+}
+
+function createAxiosClient(config, baseUrl, responseType) {
+  const headers = {
+    'Content-Type': 'application/json',
+    Accept: responseType === 'stream' ? 'text/event-stream, application/x-ndjson, application/json' : 'application/json',
+  };
+
+  if (config.apiKey) {
+    headers.Authorization = `Bearer ${config.apiKey}`;
+  }
+
+  return axios.create({
+    baseURL: baseUrl,
+    timeout: config.timeoutMs,
+    responseType,
+    headers,
+    validateStatus: () => true,
+  });
+}
+
+async function postEndpoint({ config, baseUrl, endpoint, onText }) {
+  const stream = endpoint.body.stream === true;
+  const client = createAxiosClient(config, baseUrl, stream ? 'stream' : 'json');
+  let response;
+
+  try {
+    response = await client.post(endpoint.path, endpoint.body);
+  } catch (error) {
+    if (error.code === 'ECONNABORTED' || /timeout/i.test(error.message || '')) {
+      throw makeLanguageError('Simphoni request timed out.', {
+        status: 504,
+        code: 'simphoni_timeout',
+        upstream: {
+          baseUrl: redactBaseUrl(baseUrl),
+          endpoint: endpoint.path,
+          mode: endpoint.mode,
+        },
+      });
+    }
+
+    throw makeLanguageError('Simphoni request failed before receiving a response.', {
+      status: 502,
+      code: 'simphoni_network_error',
+      detail: sanitizeErrorDetail(error.message),
+      upstream: {
+        baseUrl: redactBaseUrl(baseUrl),
+        endpoint: endpoint.path,
+        mode: endpoint.mode,
+      },
+    });
+  }
+
+  if (response.status < 200 || response.status >= 300) {
+    const detail = stream ? await readBodyText(response.data) : response.data;
+    throw makeLanguageError(`Simphoni ${endpoint.path} returned ${response.status}.`, {
+      status: response.status,
+      code: 'simphoni_upstream_error',
+      detail: sanitizeErrorDetail(detail),
+      upstream: {
+        status: response.status,
+        baseUrl: redactBaseUrl(baseUrl),
+        endpoint: endpoint.path,
+        mode: endpoint.mode,
+      },
+    });
+  }
+
+  if (stream) {
+    const collected = await collectStreamText(response.data, { onText });
+    return {
+      ...collected,
+      mode: endpoint.mode,
+      endpoint: endpoint.path,
+      baseUrl: redactBaseUrl(baseUrl),
+    };
+  }
+
+  const text = extractTextFromPayload(response.data);
+  return {
+    text: (text || '').trim(),
+    raw: response.data,
+    done: response.data?.done ?? true,
+    parseErrors: [],
+    mode: endpoint.mode,
+    endpoint: endpoint.path,
+    baseUrl: redactBaseUrl(baseUrl),
+  };
+}
+
+function assertConfigured(config) {
+  if (!config.model) {
+    throw makeLanguageError('No Simphoni model is configured.', {
+      status: 503,
+      code: 'simphoni_model_missing',
+    });
+  }
+  if (!config.baseUrls.length) {
+    throw makeLanguageError('No Simphoni base URL is configured.', {
+      status: 503,
+      code: 'simphoni_base_url_missing',
+    });
+  }
+}
+
+async function requestLanguage({ config, messages, prompt, options, onText }) {
+  assertConfigured(config);
+
+  const streams = config.streamingEnabled
+    ? [true, ...(config.nonStreamingFallbackEnabled ? [false] : [])]
+    : [false];
+  const failures = [];
+
+  for (const baseUrl of config.baseUrls) {
+    for (const stream of streams) {
+      const attempts = buildEndpointAttempts({
+        messages,
+        prompt,
+        options,
+        stream,
+        model: config.model,
+      });
+
+      for (const endpoint of attempts) {
+        try {
+          const result = await postEndpoint({ config, baseUrl, endpoint, onText: stream ? onText : undefined });
+          if (!result.text && !result.done) {
+            throw makeLanguageError('Simphoni returned an empty response.', {
+              status: 502,
+              code: 'simphoni_empty_response',
+              upstream: {
+                baseUrl: redactBaseUrl(baseUrl),
+                endpoint: endpoint.path,
+                mode: endpoint.mode,
+              },
+            });
+          }
+          return { ...result, streaming: stream };
+        } catch (error) {
+          failures.push({
+            code: error.code,
+            status: error.status,
+            detail: error.detail,
+            upstream: error.upstream || {
+              baseUrl: redactBaseUrl(baseUrl),
+              endpoint: endpoint.path,
+              mode: endpoint.mode,
+            },
+          });
+        }
+      }
+    }
+  }
+
+  const last = failures[failures.length - 1] || {};
+  const allTimeouts = failures.length > 0 && failures.every((failure) => failure.code === 'simphoni_timeout');
+  throw makeLanguageError('All configured Simphoni language routes failed.', {
+    status: allTimeouts ? 504 : (last.status && last.status >= 400 && last.status < 500 ? last.status : 502),
+    code: 'simphoni_all_routes_failed',
+    detail: last.detail,
+    attempts: failures.map((failure) => ({
+      code: failure.code,
+      status: failure.status,
+      upstream: failure.upstream,
+    })),
+  });
+}
+
+function healthMetadata(config) {
+  return {
+    provider: config.provider,
+    model_configured: Boolean(config.model),
+    model: config.model || null,
+    base_url_configured: config.configuredBaseUrls.length > 0,
+    base_url_count: config.baseUrls.length,
+    base_urls: config.baseUrls.map(redactBaseUrl),
+    streaming_enabled: config.streamingEnabled,
+    non_streaming_fallback_enabled: config.nonStreamingFallbackEnabled,
+    timeout_ms: config.timeoutMs,
+    endpoints: {
+      chat: ['/api/chat', '/v1/chat/completions', '/api/generate'],
+      generate: ['/api/generate', '/v1/completions', '/api/chat'],
+    },
+  };
+}
+
+module.exports = {
+  DEFAULT_LOCAL_BASE_URLS,
+  applyTextUpdate,
+  buildBaseList,
+  buildClientConfig,
+  buildEndpointAttempts,
+  cleanBaseUrl,
+  collectStreamText,
+  extractTextFromPayload,
+  healthMetadata,
+  messagesToPrompt,
+  parseBoolean,
+  parsePositiveInteger,
+  parseStreamLine,
+  redactBaseUrl,
+  requestLanguage,
+  sanitizeErrorDetail,
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -52,27 +52,56 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/bytes": {
@@ -744,12 +773,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -768,16 +797,45 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "start": "node server.js"
   },
   "keywords": [],

--- a/backend/server.js
+++ b/backend/server.js
@@ -102,8 +102,13 @@ async function streamReading(req, res, messages, route) {
     }
   };
 
-  req.on('close', () => {
+  req.on('aborted', () => {
     closed = true;
+  });
+  res.on('close', () => {
+    if (!res.writableEnded) {
+      closed = true;
+    }
   });
 
   try {

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,247 +2,152 @@ require('dotenv').config();
 
 const express = require('express');
 const cors = require('cors');
-const axios = require('axios');
 
 const { introPrompt } = require('./templates/psychic');
 const { psychicSpread } = require('./templates/spread');
+const {
+  buildClientConfig,
+  healthMetadata,
+  requestLanguage,
+} = require('./lib/simphoniClient');
 
 const app = express();
 const port = process.env.PORT || 5001;
-
-// These names are “OPENAI_*” but you’re actually targeting Ollama.
-// Keep env names for compatibility with deployments.
-const MODEL = process.env.CURRENT_MODEL || 'tinyllama';
-const OLLAMA_BASE_URL = (process.env.OPENAI_BASE_URL || 'http://itworksonmymachine:11434').replace(/\/$/, '');
+const simphoniConfig = buildClientConfig();
 
 app.use(cors());
 app.use(express.json({ limit: '1mb' }));
 
-/**
- * Turn chat-style messages into a single prompt string for /api/generate.
- * This keeps your template system intact even if it produces messages arrays.
- */
-function messagesToPrompt(messages) {
-  if (!Array.isArray(messages)) return String(messages || '');
-
-  return messages
-    .map((m) => {
-      const role = (m?.role || 'user').toUpperCase();
-      const content = typeof m?.content === 'string' ? m.content : JSON.stringify(m?.content ?? '');
-      return `${role}: ${content}`;
-    })
-    .join('\n')
-    .concat('\nASSISTANT:');
-}
-
-function createOllamaClient() {
-  return axios.create({
-    baseURL: OLLAMA_BASE_URL,
-    timeout: 60_000,
-    headers: { 'Content-Type': 'application/json' },
-    // Don’t throw automatically so we can inspect body on non-2xx.
-    validateStatus: () => true,
-  });
-}
-
-async function readStreamBody(stream) {
-  let text = '';
-
-  for await (const chunk of stream) {
-    text += chunk.toString('utf8');
+function normalizeCards(cards) {
+  if (!Array.isArray(cards) || cards.length === 0) {
+    const err = new Error('`cards` must be a non-empty array.');
+    err.status = 400;
+    throw err;
   }
 
-  return text;
-}
+  const normalized = cards.slice(0, 3).map((card) => ({
+    number: Number(card?.number),
+    inverted: Boolean(card?.inverted),
+  }));
 
-function buildOllamaRequest({ model, messages, prompt, options, stream = false }) {
-  if (Array.isArray(messages)) {
-    return {
-      endpoint: '/api/chat',
-      body: {
-        model,
-        messages,
-        stream,
-        options: options || undefined,
-      },
-      mode: 'chat',
-    };
+  if (normalized.some((card) => Number.isNaN(card.number))) {
+    const err = new Error('Each card must include a numeric `number`.');
+    err.status = 400;
+    throw err;
   }
 
+  return normalized;
+}
+
+function responseMeta(result) {
   return {
-    endpoint: '/api/generate',
-    body: {
-      model,
-      prompt: typeof prompt === 'string' ? prompt : messagesToPrompt(messages),
-      stream,
-      options: options || undefined,
-    },
-    mode: 'generate',
+    provider: simphoniConfig.provider,
+    model: result.raw?.model ?? simphoniConfig.model,
+    mode: result.mode,
+    endpoint: result.endpoint,
+    base_url: result.baseUrl,
+    streaming: result.streaming,
+    done: result.raw?.done ?? result.done ?? true,
+    done_reason: result.raw?.done_reason,
+    eval_count: result.raw?.eval_count,
+    total_duration: result.raw?.total_duration,
+    parse_error_count: result.parseErrors?.length || 0,
   };
 }
 
-/**
- * Call Ollama in a non-streaming way and return a clean text response.
- *
- * Uses /api/chat if you provide messages.
- * Falls back to /api/generate by converting messages -> prompt.
- */
-async function ollamaRequest({ model, messages, prompt, options }) {
-  const client = createOllamaClient();
-  const request = buildOllamaRequest({ model, messages, prompt, options, stream: false });
-  const r = await client.post(request.endpoint, request.body);
-
-  if (r.status < 200 || r.status >= 300) {
-    const detail = r.data || r.statusText;
-    const err = new Error(`Ollama ${request.endpoint} failed: ${r.status}`);
-    err.status = r.status;
-    err.detail = detail;
-    throw err;
-  }
-
-  const text = request.mode === 'chat'
-    ? (r.data?.message?.content ?? '').trim()
-    : (r.data?.response ?? '').trim();
-
-  return { text, raw: r.data, mode: request.mode };
-}
-
-async function ollamaStreamText({ req, res, model, messages, prompt, options }) {
-  const client = createOllamaClient();
-  const request = buildOllamaRequest({ model, messages, prompt, options, stream: true });
-  const r = await client.post(request.endpoint, request.body, {
-    responseType: 'stream',
-  });
-
-  if (r.status < 200 || r.status >= 300) {
-    const detail = await readStreamBody(r.data);
-    const err = new Error(`Ollama ${request.endpoint} failed: ${r.status}`);
-    err.status = r.status;
-    err.detail = detail || r.statusText;
-    throw err;
-  }
-
-  res.status(200);
-  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
-  res.setHeader('Cache-Control', 'no-cache, no-transform');
-  res.setHeader('X-Accel-Buffering', 'no');
-
-  if (typeof res.flushHeaders === 'function') {
-    res.flushHeaders();
-  }
-
-  const upstream = r.data;
-  let closed = false;
-  let buffer = '';
-
-  res.on('close', () => {
-    if (res.writableEnded) {
-      return;
-    }
-
-    closed = true;
-    upstream.destroy();
-  });
-
-  for await (const chunk of upstream) {
-    if (closed) {
-      return;
-    }
-
-    buffer += chunk.toString('utf8');
-    const lines = buffer.split('\n');
-    buffer = lines.pop() ?? '';
-
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-
-      let parsed;
-      try {
-        parsed = JSON.parse(trimmed);
-      } catch (err) {
-        console.error('[StreamParseError]', {
-          endpoint: request.endpoint,
-          line: trimmed,
-          message: err.message,
-        });
-        continue;
-      }
-
-      const text = request.mode === 'chat'
-        ? parsed?.message?.content
-        : parsed?.response;
-
-      if (text) {
-        res.write(text);
-      }
-    }
-  }
-
-  const trailing = buffer.trim();
-  if (trailing) {
-    try {
-      const parsed = JSON.parse(trailing);
-      const text = request.mode === 'chat'
-        ? parsed?.message?.content
-        : parsed?.response;
-
-      if (text) {
-        res.write(text);
-      }
-    } catch (err) {
-      console.error('[StreamParseError]', {
-        endpoint: request.endpoint,
-        line: trailing,
-        message: err.message,
-      });
-    }
-  }
-
-  res.end();
-}
-
-/**
- * Unified error responder.
- */
 function sendDownstreamError(res, err, context = {}) {
   const status = err.status && Number.isInteger(err.status) ? err.status : 502;
 
-  // Log something actually useful
-  console.error('[DownstreamError]', {
+  console.error('[LanguageServiceError]', {
     status,
+    code: err.code,
     message: err.message,
     detail: err.detail,
+    attempts: err.attempts,
     ...context,
   });
 
   return res.status(status).json({
     error: 'Language service error',
     status,
+    code: err.code || 'language_service_error',
     message: err.message,
     detail: err.detail,
+    attempts: err.attempts,
   });
+}
+
+async function runReading({ messages, onText }) {
+  return requestLanguage({
+    config: simphoniConfig,
+    messages,
+    onText,
+  });
+}
+
+async function streamReading(req, res, messages, route) {
+  let closed = false;
+  let started = false;
+
+  const startStream = () => {
+    if (started) return;
+    started = true;
+    res.status(200);
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('X-Accel-Buffering', 'no');
+
+    if (typeof res.flushHeaders === 'function') {
+      res.flushHeaders();
+    }
+  };
+
+  req.on('close', () => {
+    closed = true;
+  });
+
+  try {
+    const result = await runReading({
+      messages,
+      onText: (chunk) => {
+        if (!closed) {
+          startStream();
+          res.write(chunk);
+        }
+      },
+    });
+
+    if (!started && !closed) {
+      startStream();
+      res.write(result.text || '');
+    }
+  } catch (err) {
+    if (!res.headersSent) {
+      return sendDownstreamError(res, err, { route });
+    }
+
+    console.error('[LanguageStreamError]', {
+      route,
+      status: err.status,
+      code: err.code,
+      message: err.message,
+      detail: err.detail,
+    });
+  }
+
+  if (!closed) {
+    res.end();
+  }
 }
 
 app.post('/api/psychic/intro', async (req, res) => {
   try {
-    // Your template returns messages; use /api/chat if possible.
     const messages = introPrompt({});
-
-    const { text, mode, raw } = await ollamaRequest({
-      model: MODEL,
-      messages,
-      // You can set generation options here if desired:
-      // options: { temperature: 0.7 }
-    });
+    const result = await runReading({ messages });
 
     return res.json({
-      response: text,
-      meta: {
-        model: raw?.model ?? MODEL,
-        mode,
-        done: raw?.done ?? true,
-      },
+      response: result.text,
+      meta: responseMeta(result),
     });
   } catch (err) {
     return sendDownstreamError(res, err, { route: '/api/psychic/intro' });
@@ -250,68 +155,21 @@ app.post('/api/psychic/intro', async (req, res) => {
 });
 
 app.post('/api/psychic/intro/stream', async (req, res) => {
-  try {
-    const messages = introPrompt({});
-
-    await ollamaStreamText({
-      req,
-      res,
-      model: MODEL,
-      messages,
-    });
-  } catch (err) {
-    if (!res.headersSent) {
-      return sendDownstreamError(res, err, { route: '/api/psychic/intro/stream' });
-    }
-
-    console.error('[DownstreamError]', {
-      route: '/api/psychic/intro/stream',
-      status: err.status,
-      message: err.message,
-      detail: err.detail,
-    });
-
-    res.end();
-  }
+  const messages = introPrompt({});
+  return streamReading(req, res, messages, '/api/psychic/intro/stream');
 });
 
 app.post('/api/psychic/spread', async (req, res) => {
   try {
     const { cards = [], tone = 'warm' } = req.body || {};
-
-    if (!Array.isArray(cards) || cards.length === 0) {
-      return res.status(400).json({ error: '`cards` must be a non-empty array.' });
-    }
-
-    const normalized = cards.slice(0, 3).map((c) => ({
-      number: Number(c?.number),
-      inverted: !!c?.inverted,
-    }));
-
-    const bad = normalized.find((c) => Number.isNaN(c.number));
-    if (bad) {
-      return res.status(400).json({ error: 'Each card must include a numeric `number`.' });
-    }
-
+    const normalized = normalizeCards(cards);
     const messages = psychicSpread({ cards: normalized, tone });
-
-    const { text, mode, raw } = await ollamaRequest({
-      model: MODEL,
-      messages,
-      // options: { temperature: 0.8, top_p: 0.9 }
-    });
+    const result = await runReading({ messages });
 
     return res.json({
-      response: text,
+      response: result.text,
       used: { cards: normalized },
-      meta: {
-        model: raw?.model ?? MODEL,
-        mode,
-        done: raw?.done ?? true,
-        done_reason: raw?.done_reason,
-        eval_count: raw?.eval_count,
-        total_duration: raw?.total_duration,
-      },
+      meta: responseMeta(result),
     });
   } catch (err) {
     return sendDownstreamError(res, err, { route: '/api/psychic/spread' });
@@ -321,52 +179,34 @@ app.post('/api/psychic/spread', async (req, res) => {
 app.post('/api/psychic/spread/stream', async (req, res) => {
   try {
     const { cards = [], tone = 'warm' } = req.body || {};
-
-    if (!Array.isArray(cards) || cards.length === 0) {
-      return res.status(400).json({ error: '`cards` must be a non-empty array.' });
-    }
-
-    const normalized = cards.slice(0, 3).map((c) => ({
-      number: Number(c?.number),
-      inverted: !!c?.inverted,
-    }));
-
-    const bad = normalized.find((c) => Number.isNaN(c.number));
-    if (bad) {
-      return res.status(400).json({ error: 'Each card must include a numeric `number`.' });
-    }
-
+    const normalized = normalizeCards(cards);
     const messages = psychicSpread({ cards: normalized, tone });
-
-    await ollamaStreamText({
-      req,
-      res,
-      model: MODEL,
-      messages,
-    });
+    return streamReading(req, res, messages, '/api/psychic/spread/stream');
   } catch (err) {
-    if (!res.headersSent) {
-      return sendDownstreamError(res, err, { route: '/api/psychic/spread/stream' });
-    }
-
-    console.error('[DownstreamError]', {
-      route: '/api/psychic/spread/stream',
-      status: err.status,
-      message: err.message,
-      detail: err.detail,
-    });
-
-    res.end();
+    return sendDownstreamError(res, err, { route: '/api/psychic/spread/stream' });
   }
 });
 
 app.get('/healthz', async (req, res) => {
-  // lightweight health check (doesn't require the model to run)
-  return res.json({ ok: true, ollama: OLLAMA_BASE_URL, model: MODEL });
+  return res.json({
+    ok: true,
+    language: healthMetadata(simphoniConfig),
+  });
 });
 
-app.listen(port, () => {
-  console.log(`Server running on port ${port}`);
-  console.log(`Ollama base: ${OLLAMA_BASE_URL}`);
-  console.log(`Model: ${MODEL}`);
-});
+if (require.main === module) {
+  app.listen(port, () => {
+    const health = healthMetadata(simphoniConfig);
+    console.log(`Server running on port ${port}`);
+    console.log(`Language provider: ${health.provider}`);
+    console.log(`Model configured: ${health.model_configured ? health.model : 'no'}`);
+    console.log(`Base URLs: ${health.base_urls.join(', ') || 'none'}`);
+  });
+}
+
+module.exports = {
+  app,
+  normalizeCards,
+  responseMeta,
+  sendDownstreamError,
+};

--- a/backend/test/simphoniClient.test.js
+++ b/backend/test/simphoniClient.test.js
@@ -1,0 +1,206 @@
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { Readable } = require('node:stream');
+const test = require('node:test');
+
+const {
+  buildClientConfig,
+  buildEndpointAttempts,
+  collectStreamText,
+  healthMetadata,
+  requestLanguage,
+} = require('../lib/simphoniClient');
+
+async function readJsonBody(req) {
+  let body = '';
+  for await (const chunk of req) {
+    body += chunk.toString('utf8');
+  }
+  return body ? JSON.parse(body) : {};
+}
+
+function startMockServer(handler) {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        server,
+        baseUrl: `http://127.0.0.1:${port}`,
+      });
+    });
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function testConfig(baseUrl, overrides = {}) {
+  return buildClientConfig({
+    SIMPHONI_API_BASE_URL: baseUrl,
+    SIMPHONI_MODEL: 'ministral-3:14b',
+    SIMPHONI_TIMEOUT_MS: '1000',
+    SIMPHONI_INCLUDE_LOCAL_FALLBACKS: '0',
+    ...overrides,
+  });
+}
+
+test('builds Apex/Simphoni chat attempts before compatibility fallbacks', () => {
+  const attempts = buildEndpointAttempts({
+    model: 'ministral-3:14b',
+    messages: [{ role: 'user', content: 'Read the cards.' }],
+    stream: true,
+  });
+
+  assert.deepEqual(
+    attempts.map((attempt) => attempt.path),
+    ['/api/chat', '/v1/chat/completions', '/api/generate'],
+  );
+  assert.equal(attempts[0].body.model, 'ministral-3:14b');
+  assert.equal(attempts[0].body.stream, true);
+  assert.deepEqual(attempts[0].body.messages, [{ role: 'user', content: 'Read the cards.' }]);
+});
+
+test('collects newline and SSE stream chunks split across frames', async () => {
+  const stream = Readable.from([
+    'data: {"response":"Hel',
+    'lo"}\n',
+    'not json\n',
+    '{"response":"Hello world"}\n',
+    'data: [DONE]\n',
+  ]);
+  const deltas = [];
+
+  const result = await collectStreamText(stream, {
+    onText: (delta, fullText) => deltas.push({ delta, fullText }),
+  });
+
+  assert.equal(result.text, 'Hello world');
+  assert.equal(result.done, true);
+  assert.equal(result.parseErrors.length, 1);
+  assert.deepEqual(deltas, [
+    { delta: 'Hello', fullText: 'Hello' },
+    { delta: ' world', fullText: 'Hello world' },
+  ]);
+});
+
+test('falls back from /api/chat to OpenAI-compatible streaming endpoint', async () => {
+  const calls = [];
+  const { server, baseUrl } = await startMockServer(async (req, res) => {
+    const body = await readJsonBody(req);
+    calls.push({ path: req.url, body });
+
+    if (req.url === '/api/chat') {
+      res.writeHead(503, { 'Content-Type': 'text/plain' });
+      res.end('chat route unavailable');
+      return;
+    }
+
+    if (req.url === '/v1/chat/completions') {
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      res.write('data: {"choices":[{"delta":{"content":"fallback"}}]}\n\n');
+      res.write('data: {"choices":[{"delta":{"content":" ok"}}]}\n\n');
+      res.end('data: [DONE]\n\n');
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+
+  try {
+    const result = await requestLanguage({
+      config: testConfig(baseUrl),
+      messages: [{ role: 'user', content: 'Read the spread.' }],
+    });
+
+    assert.equal(result.text, 'fallback ok');
+    assert.equal(result.endpoint, '/v1/chat/completions');
+    assert.equal(calls[0].body.model, 'ministral-3:14b');
+    assert.equal(calls[0].body.stream, true);
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      ['/api/chat', '/v1/chat/completions'],
+    );
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('uses non-streaming fallback when streaming is rejected', async () => {
+  const calls = [];
+  const { server, baseUrl } = await startMockServer(async (req, res) => {
+    const body = await readJsonBody(req);
+    calls.push({ path: req.url, body });
+
+    if (body.stream === true) {
+      res.writeHead(501, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'streaming disabled' }));
+      return;
+    }
+
+    if (req.url === '/api/chat') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ message: { content: 'plain response' }, done: true }));
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+
+  try {
+    const result = await requestLanguage({
+      config: testConfig(baseUrl, { SIMPHONI_NON_STREAMING_FALLBACK: '1' }),
+      messages: [{ role: 'user', content: 'Read the spread.' }],
+    });
+
+    assert.equal(result.text, 'plain response');
+    assert.equal(result.streaming, false);
+    assert.equal(result.endpoint, '/api/chat');
+    assert.equal(calls.some((call) => call.body.stream === true), true);
+    assert.equal(calls.some((call) => call.body.stream === false), true);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('surfaces timeout failures without leaking configured credentials', async () => {
+  const { server, baseUrl } = await startMockServer(async (req, res) => {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ response: 'too late' }));
+  });
+
+  try {
+    await assert.rejects(
+      requestLanguage({
+        config: testConfig(baseUrl, {
+          SIMPHONI_TIMEOUT_MS: '30',
+          SIMPHONI_NON_STREAMING_FALLBACK: '0',
+        }),
+        messages: [{ role: 'user', content: 'Read the spread.' }],
+      }),
+      (err) => {
+        assert.equal(err.code, 'simphoni_all_routes_failed');
+        assert.equal(err.status, 504);
+        assert.equal(err.attempts.every((attempt) => attempt.code === 'simphoni_timeout'), true);
+        return true;
+      },
+    );
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('health metadata redacts credentials from base URLs', () => {
+  const config = testConfig('https://user:secret@example.test/api');
+  const health = healthMetadata(config);
+
+  assert.equal(health.base_url_configured, true);
+  assert.deepEqual(health.base_urls, ['https://example.test/api']);
+  assert.equal(health.model_configured, true);
+});

--- a/backend/test/simphoniClient.test.js
+++ b/backend/test/simphoniClient.test.js
@@ -168,6 +168,45 @@ test('uses non-streaming fallback when streaming is rejected', async () => {
   }
 });
 
+test('rotates configured base URLs while preserving fallback order', async () => {
+  const calls = [];
+  const first = await startMockServer(async (req, res) => {
+    await readJsonBody(req);
+    calls.push('first');
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: { content: 'first response' }, done: true }));
+  });
+  const second = await startMockServer(async (req, res) => {
+    await readJsonBody(req);
+    calls.push('second');
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: { content: 'second response' }, done: true }));
+  });
+
+  const config = testConfig(first.baseUrl, {
+    SIMPHONI_FALLBACK_BASE_URLS: second.baseUrl,
+    SIMPHONI_STREAMING_ENABLED: '0',
+  });
+
+  try {
+    const one = await requestLanguage({
+      config,
+      messages: [{ role: 'user', content: 'Read the spread.' }],
+    });
+    const two = await requestLanguage({
+      config,
+      messages: [{ role: 'user', content: 'Read the spread.' }],
+    });
+
+    assert.equal(one.text, 'first response');
+    assert.equal(two.text, 'second response');
+    assert.deepEqual(calls, ['first', 'second']);
+  } finally {
+    await closeServer(first.server);
+    await closeServer(second.server);
+  }
+});
+
 test('surfaces timeout failures without leaking configured credentials', async () => {
   const { server, baseUrl } = await startMockServer(async (req, res) => {
     await new Promise((resolve) => setTimeout(resolve, 100));

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -209,14 +209,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -555,9 +552,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -575,9 +569,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -595,9 +586,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -615,9 +603,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -635,9 +620,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -655,9 +637,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1513,9 +1492,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1537,9 +1513,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1561,9 +1534,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1585,9 +1555,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1888,13 +1855,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",

--- a/frontend/src/ClassicSpread.jsx
+++ b/frontend/src/ClassicSpread.jsx
@@ -113,11 +113,18 @@ const ClassicSpread = () => {
             <h3>{['The Past', 'The Present', 'The Future'][index]}</h3>
             {card && (
               <img
-                src={`/waite-deck/card${card.number}.jpg`}
+                src={`/waite-deck/card${card.number}.png`}
                 alt={`${getCardData(card.number)?.name || 'Unknown Card'}: ${
                   getCardData(card.number)?.description || ''
                 }`}
                 className={`card-image ${card.inverted ? 'inverted' : ''}`}
+                onError={(event) => {
+                  if (event.currentTarget.dataset.fallback === 'jpg') {
+                    return;
+                  }
+                  event.currentTarget.dataset.fallback = 'jpg';
+                  event.currentTarget.src = `/waite-deck/card${card.number}.jpg`;
+                }}
                 style={{ transform: card.inverted ? 'rotate(180deg)' : 'none' }}
               />
             )}

--- a/frontend/src/spa/TwilightTarotGardenTool.css
+++ b/frontend/src/spa/TwilightTarotGardenTool.css
@@ -1,0 +1,369 @@
+
+.twilight-tarot-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  height: 100%;
+  color: #f7efff;
+  position: relative;
+  overflow: hidden;
+  padding-bottom: 1rem;
+  background: var(
+      --ttg-background,
+      linear-gradient(135deg, rgba(43, 0, 79, 0.92), rgba(13, 1, 41, 0.96))
+    );
+}
+
+.twilight-tarot-aurora {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+      circle at 10% 10%,
+      rgba(255, 255, 255, 0.1),
+      transparent 40%
+    ),
+    radial-gradient(circle at 90% 20%, rgba(255, 255, 255, 0.08), transparent 45%);
+  pointer-events: none;
+  opacity: 0.9;
+  mix-blend-mode: screen;
+  animation: twilightDrift 16s ease-in-out infinite alternate;
+  transform-origin: center;
+  z-index: 0;
+}
+
+@keyframes twilightDrift {
+  0% {
+    transform: scale(1) translate3d(0, 0, 0);
+    opacity: 0.65;
+  }
+  50% {
+    transform: scale(1.04) translate3d(-12px, 6px, 0);
+    opacity: 0.92;
+  }
+  100% {
+    transform: scale(1.02) translate3d(10px, -8px, 0);
+    opacity: 0.7;
+  }
+}
+
+.twilight-tarot-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  padding: 1rem 1.5rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  position: relative;
+  z-index: 1;
+}
+
+.twilight-tarot-heading h1 {
+  margin: 0;
+  font-size: 2rem;
+  color: var(--ttg-accent, #c995ff);
+  letter-spacing: 0.03em;
+  text-shadow: 0 0 18px rgba(198, 149, 255, 0.4);
+}
+
+.twilight-tarot-heading p {
+  margin: 0.4rem 0 0;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.twilight-tarot-updates {
+  margin-top: 0.75rem;
+  padding: 0.6rem 0.8rem;
+  border-radius: 12px;
+  border: 1px solid var(--ttg-accent-soft, rgba(201, 149, 255, 0.24));
+  background: rgba(20, 1, 35, 0.6);
+  box-shadow: 0 12px 40px rgba(8, 0, 20, 0.35);
+}
+
+.twilight-tarot-tagline {
+  text-transform: uppercase;
+  letter-spacing: 0.26rem;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.56);
+}
+
+.twilight-tarot-close {
+  align-self: flex-start;
+  background: rgba(84, 20, 122, 0.85);
+  border: 1px solid rgba(201, 149, 255, 0.6);
+  border-radius: 999px;
+  color: #f6e9ff;
+  padding: 0.6rem 1.4rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.twilight-tarot-close:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 18px rgba(120, 40, 180, 0.35);
+}
+
+.twilight-tarot-layout {
+  display: flex;
+  flex: 1 1 auto;
+  gap: 1.5rem;
+  padding: 0 1.5rem 1.5rem;
+  overflow: hidden;
+  position: relative;
+  z-index: 1;
+}
+
+.twilight-tarot-sidebar {
+  flex: 0 0 28%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  background: rgba(28, 2, 37, 0.82);
+  border: 1px solid rgba(201, 149, 255, 0.35);
+  border-radius: 14px;
+  padding: 1.2rem;
+  overflow-y: auto;
+  box-shadow: inset 0 0 35px rgba(0, 0, 0, 0.28);
+}
+
+.twilight-tarot-sidebar section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.twilight-tarot-sidebar section:last-of-type {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.twilight-tarot-sidebar h2,
+.twilight-tarot-sidebar h3 {
+  margin: 0;
+  color: var(--ttg-accent, #c995ff);
+  letter-spacing: 0.02em;
+}
+
+.twilight-tarot-sidebar ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  line-height: 1.5;
+}
+
+.twilight-tarot-sidebar li {
+  margin-bottom: 0.6rem;
+}
+
+.twilight-tarot-section-caption {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.twilight-tarot-palettes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.twilight-tarot-palette {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+  background: rgba(12, 0, 22, 0.8);
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border 0.25s ease;
+  text-align: left;
+}
+
+.twilight-tarot-palette strong {
+  font-size: 0.95rem;
+}
+
+.twilight-tarot-palette span:last-child {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.twilight-tarot-palette .twilight-tarot-palette-sheen {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.16), transparent 55%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.twilight-tarot-palette.is-active,
+.twilight-tarot-palette:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 28px rgba(10, 0, 20, 0.35);
+  border-color: var(--ttg-accent-soft, rgba(201, 149, 255, 0.35));
+}
+
+.twilight-tarot-palette.is-active .twilight-tarot-palette-sheen,
+.twilight-tarot-palette:hover .twilight-tarot-palette-sheen {
+  opacity: 1;
+}
+
+.twilight-tarot-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(10, 0, 20, 0.76);
+  padding: 0.9rem;
+  box-shadow: inset 0 0 25px rgba(0, 0, 0, 0.28);
+}
+
+.twilight-tarot-card--luminous {
+  background: rgba(15, 0, 35, 0.7);
+  border-color: var(--ttg-accent-soft, rgba(201, 149, 255, 0.28));
+  box-shadow: 0 0 25px rgba(0, 0, 0, 0.24), 0 0 18px var(--ttg-accent-soft, rgba(201, 149, 255, 0.18));
+}
+
+.twilight-tarot-card button,
+.twilight-tarot-sidebar button {
+  align-self: flex-start;
+  background: linear-gradient(120deg, rgba(88, 32, 150, 0.82), rgba(149, 86, 220, 0.84));
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 999px;
+  color: #fdf9ff;
+  padding: 0.45rem 1.1rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.twilight-tarot-card button:hover,
+.twilight-tarot-sidebar button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(120, 40, 190, 0.45);
+}
+
+.twilight-tarot-sidebar textarea {
+  min-height: 120px;
+  resize: vertical;
+  border-radius: 10px;
+  border: 1px solid rgba(201, 149, 255, 0.35);
+  background: rgba(8, 0, 16, 0.7);
+  color: #f7efff;
+  padding: 0.75rem;
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+.twilight-tarot-sidebar textarea:focus {
+  outline: 2px solid rgba(190, 120, 255, 0.6);
+  box-shadow: 0 0 12px rgba(190, 120, 255, 0.35);
+}
+
+.twilight-tarot-outline {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.twilight-tarot-outline label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.twilight-tarot-outline span {
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.twilight-tarot-outline textarea {
+  min-height: 80px;
+}
+
+.twilight-tarot-ritual {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.9rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(8, 0, 18, 0.72);
+  box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.24);
+}
+
+.twilight-tarot-ritual-step {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16rem;
+  color: rgba(255, 255, 255, 0.62);
+}
+
+.twilight-tarot-main {
+  flex: 1 1 auto;
+  background: rgba(16, 0, 30, 0.82);
+  border: 1px solid rgba(141, 102, 255, 0.35);
+  border-radius: 16px;
+  padding: 0.8rem 0.6rem;
+  overflow-y: auto;
+  position: relative;
+  box-shadow: inset 0 0 38px rgba(0, 0, 0, 0.35);
+}
+
+.twilight-tarot-main-banner {
+  margin: 0 0 1rem;
+  padding: 0.65rem 1.2rem;
+  border-radius: 12px;
+  border: 1px solid var(--ttg-accent-soft, rgba(141, 102, 255, 0.28));
+  background: rgba(12, 0, 28, 0.76);
+  color: rgba(255, 255, 255, 0.86);
+  font-size: 0.95rem;
+  box-shadow: 0 0 25px rgba(12, 0, 25, 0.32);
+}
+
+.twilight-tarot-main .MainLoop-container {
+  min-height: auto;
+  padding: 1.5rem 0.5rem 2rem;
+}
+
+@media (max-width: 1280px) {
+  .twilight-tarot-layout {
+    flex-direction: column;
+  }
+
+  .twilight-tarot-sidebar {
+    flex: 0 0 auto;
+    order: 2;
+  }
+
+  .twilight-tarot-main {
+    order: 1;
+    min-height: 320px;
+  }
+}
+
+@media (max-width: 768px) {
+  .twilight-tarot-header {
+    flex-direction: column;
+  }
+
+  .twilight-tarot-close {
+    align-self: stretch;
+    text-align: center;
+  }
+
+  .twilight-tarot-layout {
+    padding: 0 0.5rem 1rem;
+  }
+}

--- a/frontend/src/spa/TwilightTarotGardenTool.jsx
+++ b/frontend/src/spa/TwilightTarotGardenTool.jsx
@@ -1,0 +1,275 @@
+import React, { useState } from 'react';
+import MainLoop from '../MainLoop';
+import './TwilightTarotGardenTool.css';
+
+const paletteOptions = [
+  {
+    name: 'Dusk Bloom',
+    description: 'Lavender twilight with rose glow',
+    gradient:
+      'radial-gradient(circle at 20% 20%, rgba(196, 165, 255, 0.35), transparent 60%), linear-gradient(135deg, rgba(43, 0, 79, 0.92), rgba(13, 1, 41, 0.96))',
+    accent: '#f6aaff',
+    accentSoft: 'rgba(246, 170, 255, 0.2)',
+  },
+  {
+    name: 'Aurora Ink',
+    description: 'Teal starlight shimmering over midnight',
+    gradient:
+      'radial-gradient(circle at 80% 10%, rgba(87, 242, 255, 0.18), transparent 55%), linear-gradient(160deg, rgba(9, 12, 60, 0.94), rgba(3, 0, 22, 0.94))',
+    accent: '#7df3ff',
+    accentSoft: 'rgba(125, 243, 255, 0.22)',
+  },
+  {
+    name: 'Golden Hour',
+    description: 'Amber lantern light for mythic tales',
+    gradient:
+      'radial-gradient(circle at 50% 0%, rgba(255, 197, 111, 0.26), transparent 60%), linear-gradient(140deg, rgba(58, 4, 16, 0.96), rgba(11, 0, 41, 0.92))',
+    accent: '#ffdf9d',
+    accentSoft: 'rgba(255, 223, 157, 0.24)',
+  },
+];
+
+const storySeeds = [
+  'A wandering bard discovers an oracle hidden in a lantern and must trade a memory for a prophecy.',
+  'Two rivals draw cards at dawn; the spread insists they must co-write the peace treaty or lose their kingdoms.',
+  'A forgotten temple awakens whenever the Moon card appears—what story is it begging you to tell tonight?',
+  'The Empress falls from the spread, signaling a missing caretaker in your world. Who answers the call?',
+  'An inverted Sun challenges your protagonist to navigate hope through shadowed corridors.',
+];
+
+const plotTwists = [
+  'The chosen guide is secretly tethered to the antagonist through a sacred vow.',
+  'A card repeats three nights in a row, unlocking a hidden location in the story world.',
+  'Tarot whispers that the mentor has been reading the protagonist’s diary all along.',
+  'The deck refuses to reveal the final card until a side character speaks their truth.',
+  'A reversed card amplifies the scene’s soundtrack—lyrics emerge that rewrite the conflict.',
+];
+
+const ritualSteps = [
+  'Light a candle (real or imagined) and write one line about its color before you draw.',
+  'Shuffle the cards while naming three emotions you want in the next scene.',
+  'Journal a single sensory detail for each card in your spread; weave them into a paragraph.',
+  'Set a timer for five minutes and free-write dialogue sparked by the crossing card.',
+  'When you finish, pull one more card and let it title your chapter or poem.',
+];
+
+const outlineFields = [
+  {
+    key: 'openingImage',
+    label: 'Opening Image',
+    placeholder: 'What visual sets the tone as the spread sparks your scene?',
+  },
+  {
+    key: 'complication',
+    label: 'Complication',
+    placeholder: 'Which card complicates your protagonist’s plan?',
+  },
+  {
+    key: 'revelation',
+    label: 'Revelation',
+    placeholder: 'What secret or insight surfaces near the final position?',
+  },
+];
+
+function TwilightTarotGardenTool({ onClose }) {
+  const [notes, setNotes] = useState('');
+  const [paletteIndex, setPaletteIndex] = useState(0);
+  const [storySeedIndex, setStorySeedIndex] = useState(() =>
+    Math.floor(Math.random() * storySeeds.length),
+  );
+  const [plotTwistIndex, setPlotTwistIndex] = useState(() =>
+    Math.floor(Math.random() * plotTwists.length),
+  );
+  const [ritualIndex, setRitualIndex] = useState(() =>
+    Math.floor(Math.random() * ritualSteps.length),
+  );
+  const [outlineNotes, setOutlineNotes] = useState(() =>
+    outlineFields.reduce((memo, field) => ({ ...memo, [field.key]: '' }), {}),
+  );
+
+  const activePalette = paletteOptions[paletteIndex];
+
+  const reshuffleSeed = () => {
+    setStorySeedIndex((prev) => {
+      let next = Math.floor(Math.random() * storySeeds.length);
+      if (next === prev) {
+        next = (next + 1) % storySeeds.length;
+      }
+      return next;
+    });
+  };
+
+  const reshuffleTwist = () => {
+    setPlotTwistIndex((prev) => {
+      let next = Math.floor(Math.random() * plotTwists.length);
+      if (next === prev) {
+        next = (next + 1) % plotTwists.length;
+      }
+      return next;
+    });
+  };
+
+  const advanceRitual = () => {
+    setRitualIndex((prev) => (prev + 1) % ritualSteps.length);
+  };
+
+  const updateOutline = (key, value) => {
+    setOutlineNotes((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <div
+      className="twilight-tarot-tool"
+      style={{
+        '--ttg-background': activePalette.gradient,
+        '--ttg-accent': activePalette.accent,
+        '--ttg-accent-soft': activePalette.accentSoft,
+      }}
+    >
+      <div className="twilight-tarot-aurora" aria-hidden="true" />
+      <header className="twilight-tarot-header">
+        <div className="twilight-tarot-heading">
+          <p className="twilight-tarot-tagline">Creative Writers Mini-App</p>
+          <h1>Twilight Tarot Garden</h1>
+          <p>
+            Fan out the major arcana, invite characters into the spread, and let each
+            card spark a scene, poem, or journal entry. Use the spread to map turning
+            points or inner monologues before you write.
+          </p>
+          <p className="twilight-tarot-updates">
+            New this season: sculpt the garden’s mood, spin fresh story seeds, and map
+            your plot beats alongside the live spread.
+          </p>
+        </div>
+        <button type="button" className="twilight-tarot-close" onClick={onClose}>
+          Return to Communiti
+        </button>
+      </header>
+
+      <div className="twilight-tarot-layout">
+        <aside className="twilight-tarot-sidebar">
+          <section>
+            <h2>Writing with Tarot</h2>
+            <ul>
+              <li>Click "Hello traveler" to summon an opening invitation to your story world.</li>
+              <li>Draw a spread and assign each card to a beat: inciting spark, revelation, or mood.</li>
+              <li>Let inverted cards introduce conflict or unexpected character choices.</li>
+              <li>After the reading, free-write for five minutes using the cards as guideposts.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h3>Garden Mood Palette</h3>
+            <p className="twilight-tarot-section-caption">
+              Shift the gradient and accent lights to match the tone of your next scene.
+            </p>
+            <div className="twilight-tarot-palettes">
+              {paletteOptions.map((palette, index) => (
+                <button
+                  key={palette.name}
+                  type="button"
+                  className={`twilight-tarot-palette ${
+                    index === paletteIndex ? 'is-active' : ''
+                  }`}
+                  onClick={() => setPaletteIndex(index)}
+                >
+                  <span className="twilight-tarot-palette-sheen" />
+                  <strong>{palette.name}</strong>
+                  <span>{palette.description}</span>
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h3>Story Seed</h3>
+            <p className="twilight-tarot-section-caption">
+              Use the seed as an inciting image or opening paragraph and branch outward.
+            </p>
+            <div className="twilight-tarot-card twilight-tarot-card--luminous">
+              <p>{storySeeds[storySeedIndex]}</p>
+              <button type="button" onClick={reshuffleSeed}>
+                Draw another seed
+              </button>
+            </div>
+          </section>
+
+          <section>
+            <h3>Plot Twist Echo</h3>
+            <p className="twilight-tarot-section-caption">
+              When the spread settles, drop this twist into the middle of your scene.
+            </p>
+            <div className="twilight-tarot-card">
+              <p>{plotTwists[plotTwistIndex]}</p>
+              <button type="button" onClick={reshuffleTwist}>
+                Reveal another twist
+              </button>
+            </div>
+          </section>
+
+          <section>
+            <h3>Creative Ritual</h3>
+            <div className="twilight-tarot-ritual">
+              <span className="twilight-tarot-ritual-step">
+                Step {ritualIndex + 1} of {ritualSteps.length}
+              </span>
+              <p>{ritualSteps[ritualIndex]}</p>
+              <button type="button" onClick={advanceRitual}>
+                Next ritual cue
+              </button>
+            </div>
+          </section>
+
+          <section>
+            <h3>Scene Sketchpad</h3>
+            <textarea
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              placeholder="Capture the character voice, setting details, or bits of dialogue inspired by the cards..."
+            />
+          </section>
+
+          <section>
+            <h3>Three-Beat Outline</h3>
+            <p className="twilight-tarot-section-caption">
+              Anchor the spread to your narrative arc while it is fresh.
+            </p>
+            <div className="twilight-tarot-outline">
+              {outlineFields.map((field) => (
+                <label key={field.key}>
+                  <span>{field.label}</span>
+                  <textarea
+                    value={outlineNotes[field.key]}
+                    onChange={(event) => updateOutline(field.key, event.target.value)}
+                    placeholder={field.placeholder}
+                  />
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h3>Prompt Hooks</h3>
+            <ul>
+              <li>Pair the Fool with a setting to start a journey-focused scene.</li>
+              <li>Use the card crossing the present as the obstacle your protagonist resists.</li>
+              <li>Translate the final outcome card into the last line of a poem or chapter.</li>
+            </ul>
+          </section>
+        </aside>
+
+        <div className="twilight-tarot-main">
+          <div className="twilight-tarot-main-banner">
+            <p>
+              Ready to write? Choose a palette, spin a story seed, then click into the
+              live wave of cards to conjure your next chapter.
+            </p>
+          </div>
+          <MainLoop />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TwilightTarotGardenTool;

--- a/kubernetes/backend-deployment.yaml
+++ b/kubernetes/backend-deployment.yaml
@@ -18,13 +18,23 @@ spec:
       - name: test-backend
         image: zaptapped/my-first-container:v6.0.0
         env:
-        - name: OPENAI_BASE_URL
+        - name: SIMPHONI_API_BASE_URL
           value: "http://192.168.1.10:11434"
-        - name: CURRENT_MODEL
+        - name: SIMPHONI_MODEL
           valueFrom:
             configMapKeyRef:
               name: tarot-config
-              key: CURRENT_MODEL
+              key: SIMPHONI_MODEL
+        - name: SIMPHONI_TIMEOUT_MS
+          valueFrom:
+            configMapKeyRef:
+              name: tarot-config
+              key: SIMPHONI_TIMEOUT_MS
+        - name: SIMPHONI_STREAMING_ENABLED
+          valueFrom:
+            configMapKeyRef:
+              name: tarot-config
+              key: SIMPHONI_STREAMING_ENABLED
         ports:
           - name: backend
             containerPort: 5001

--- a/kubernetes/tarot-config.yaml
+++ b/kubernetes/tarot-config.yaml
@@ -3,5 +3,8 @@ kind: ConfigMap
 metadata:
   name: tarot-config
 data:
+  SIMPHONI_MODEL: "ministral-3:14b"
+  SIMPHONI_TIMEOUT_MS: "120000"
+  SIMPHONI_STREAMING_ENABLED: "true"
   CURRENT_MODEL: "ministral-3:14b"
-  # Other models to try? ministral-3:14b, gemma3:latest
+  # CURRENT_MODEL is retained for older deployments. Other models to try? ministral-3:14b, gemma3:latest


### PR DESCRIPTION
## Summary
- Forward-ports the useful Apex-01/Simphoni routing idea from `wire-llm-calls-to-apex-01` onto current `origin/main` instead of merging the stale branch.
- Replaces the backend Ollama-only path with a configurable Simphoni/Apex client using `SIMPHONI_API_BASE_URL`, `SIMPHONI_MODEL`, `SIMPHONI_TIMEOUT_MS`, streaming toggles, API-key support, redacted health metadata, and endpoint fallback ordering.
- Keeps the current `/api/psychic/*` and `/api/psychic/*/stream` app contract while adding robust SSE/newline stream parsing, non-streaming fallback, upstream timeout handling, and sanitized client-facing errors.

## Preserved from current main
- Preserved the newer tarot prompt work in `backend/templates/spread.js` unchanged.
- Preserved the Vite frontend structure and current streaming UI work.
- Preserved current deployment host/image direction, including `tarot.catdadservices.com`, frontend image `zaptapped/tarot-frontend:v1.0.2`, and backend image `zaptapped/my-first-container:v6.0.0`.
- Kept Kubernetes shape intact while moving backend env names to the Simphoni config surface.

## Apex-01 / Simphoni configuration
- Primary env: `SIMPHONI_API_BASE_URL`, `SIMPHONI_MODEL`.
- Optional env: `SIMPHONI_TIMEOUT_MS`, `SIMPHONI_STREAMING_ENABLED`, `SIMPHONI_NON_STREAMING_FALLBACK`, `SIMPHONI_FALLBACK_BASE_URLS`, `SIMPHONI_INCLUDE_LOCAL_FALLBACKS`, `SIMPHONI_API_KEY`, `SIMPHONI_API_TOKEN`.
- Compatibility envs remain accepted: `CURRENT_MODEL`, `OPENAI_MODEL`, `OPENAI_BASE_URL`, `OLLAMA_BASE_URL`.
- Chat attempts are ordered `/api/chat`, `/v1/chat/completions`, then `/api/generate`; prompt attempts are ordered `/api/generate`, `/v1/completions`, then `/api/chat`.
- Health metadata reports provider/model/base URL presence and redacted base URLs only; credentials are never exposed.

## Dependency and security updates
- Backend audit fixed by lockfile updates to patched `body-parser`/`qs` transitive versions.
- Frontend audit fixed by lockfile bumping vulnerable transitive `@babel/runtime`.
- Removed `COPY .env` from the backend Dockerfile so secrets/config are supplied at runtime.
- Added `.env.example` with non-secret Simphoni configuration placeholders.

## Validation
- `git fetch --all --prune` completed before branching from current `origin/main`.
- `npm install` in `backend/`: completed; initial audit finding fixed.
- `npm test` in `backend/`: 6 tests passed.
- `npm audit --json` in `backend/`: 0 vulnerabilities.
- `npm audit fix` in `frontend/`: completed and cleared the transitive Babel audit finding.
- `npm test` in `frontend/`: 1 file / 2 tests passed.
- `npm run build` in `frontend/`: Vite build succeeded.
- `node --check backend/server.js` and `node --check backend/lib/simphoniClient.js`: passed.
- Mock route smoke through `/api/psychic/spread`: returned HTTP 200 using mocked `/api/chat` stream.
- Kubernetes: `kubectl apply --dry-run=client --validate=false -f kubernetes` was blocked by current kube credentials; local Ruby YAML parse passed for all manifest files.
- Secret scan over the repo excluding `node_modules` and build output found no API keys/tokens/private keys.

## Live Apex-01 smoke
- Not performed. This shell did not have `SIMPHONI_API_BASE_URL`, `SIMPHONI_MODEL`, `SIMPHONI_API_KEY`, or `SIMPHONI_API_TOKEN` exported, and this PR intentionally does not guess production URLs or credentials.

## Risks and follow-up
- The Kubernetes manifest still points `SIMPHONI_API_BASE_URL` at the existing deployment host value, so operators should confirm that host currently exposes one of the compatible routes before rollout.
- Broader frontend modernization is intentionally out of scope. Current `main` is already on Vite, and this PR only applies the small audit lockfile fix.
- A real Apex-01 smoke should be run in the deployment environment with the production Simphoni env vars before promotion.